### PR TITLE
Mint support. Create executable target that runs lefthook binary from artifact bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,14 @@ jobs:
         bootstrap: false
     - name: Run mint
       run: mint run ${{ github.repository }}@${{ github.head_ref }} --help
+  
+  swift-executable:
+    name: Checks for running executable with swift run 
+    runs-on: macOS-14
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run executable with Swift 
+      run: swift run --help 
 
   Linux:
     runs-on: ubuntu-latest

--- a/Executable/ArtifactParser.swift
+++ b/Executable/ArtifactParser.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Parses the lefthook artifact bundle to find the correct executable binary to run for the given OS. 
+/// 
+/// This code is heavily inspired by the Swift Package Manager's implementation of parsing artifact bundles. Links to reference code are provided in the comments.
+class ArtifactParser {
+    
+    /// Parses the unzipped artifact bundle to find the correct lefthook binary to run for the given OS.
+    ///
+    /// Reference: https://github.com/apple/swift-package-manager/blob/1c68e6cab56a3acba30d3ecea0c09209c6c7f565/Sources/SPMBuildCore/BinaryTarget%2BExtensions.swift#L59-L85    
+    static func getPathToLefthookBinary() -> String? {
+        // 1. Get the tuple.
+        // https://github.com/apple/swift-package-manager/blob/1c68e6cab56a3acba30d3ecea0c09209c6c7f565/Sources/SPMBuildCore/BinaryTarget%2BExtensions.swift#L61
+        // 
+        // If you look in an artifactbundle.zip, you will see a file called info.json that defines what executables belong to what OS. 
+        // Swift uses a term "triples" to determine the OS and architecture of the system.
+        // To be able to find the correct binary to execute, we need to get the system triple. 
+        guard let systemTriple = OS.getSystemTriple() else {
+            return nil
+        }
+
+        // 2. Parse the artifact bundle's info.json manifest file to get list of all available executable binaries. 
+        // https://github.com/apple/swift-package-manager/blob/1c68e6cab56a3acba30d3ecea0c09209c6c7f565/Sources/SPMBuildCore/BinaryTarget%2BExtensions.swift#L63-L66
+        // 
+        // Luckily, SPM has already downloaded and unzipped the remote artifactbundle.zip by the time this executable target is compiled.
+        // SPM downloads the artifactbundle.zip because we define a binaryTarget dependency. It unzips it to the .build directory because we define a pre-build plugin that's executed before this target is compiled.                
+        guard let rootDirectoryOfArtifactBundle = getArtifactBundlePath() else {
+            print("Unexpected error. Unable to find an artifact bundle directory that contains lefthook executables.")
+            return nil
+        }
+        
+        let infoJsonPath = "\(rootDirectoryOfArtifactBundle)/info.json"
+        guard let infoJsonFileContents: Data = try? Data(contentsOf: URL(fileURLWithPath: infoJsonPath)) else {
+            print("Unexpected error. Unable to read info.json file. Perhaps the path is incorrect? Given path: \(infoJsonPath)")
+            return nil
+        }
+        
+        guard let infoJsonParsed: ArtifactBundleInfo = try? JSONDecoder().decode(ArtifactBundleInfo.self, from: infoJsonFileContents) else {
+            print("Unexpected error. Unable to parse manifest file json. Check if \(infoJsonPath) format is compatible with \(ArtifactBundleInfo.self) data type.")
+            return nil
+        }
+
+        // 3. Lastly, take the system tuple and use that to find the 1 binary that we should run. 
+        // https://github.com/apple/swift-package-manager/blob/1c68e6cab56a3acba30d3ecea0c09209c6c7f565/Sources/SPMBuildCore/BinaryTarget%2BExtensions.swift#L75-L81
+        guard let binaryFileNameForOS = infoJsonParsed.artifacts.lefthook.variants.first(where: { $0.supportedTriples.contains(systemTriple) })?.path else {
+            print("According to the artifact bundle manifest file, no lefthook binary exists for the given OS: \(systemTriple)")
+            return nil
+        }
+
+        return "\(rootDirectoryOfArtifactBundle)/\(binaryFileNameForOS)"
+    }
+    
+    // Get the path to the root directory of the artifact bundle. The root is considered to be the path where the info.json file exists.
+    // Depending on how you execute the executable target, the artifact bundle path will be different.
+    static func getArtifactBundlePath() -> String? {
+        // For local "swift run" development, the path is:
+        let localDevelopmentPath = ".build/artifacts/lefthook-plugin/lefthook"
+        if let absolutePath = FileSystem.getAbsolutePathThatExists(relativePath: localDevelopmentPath) {
+            return absolutePath
+        }
+        
+        // If you run the executable with mint, the path relative to the executable will follow this pattern:
+        // "artifacts/github.com_*/lefthook"
+        // The path name is determined by the github repository name.
+        if let absolutePathToMintResources = FileSystem.getAbsolutePathThatExists(relativePath: "artifacts"),
+            let absoluteMintArtifactPath = FileSystem.getSubdirectories(atAbsolutePath: absolutePathToMintResources).first(where: { $0.contains("github.com_") }) {
+            if let absolutePath = FileSystem.getAbsolutePathThatExists(relativePath: "\(absoluteMintArtifactPath)/lefthook") {
+                return absolutePath
+            }
+        }
+        
+        return nil
+    }
+
+    // Struct to parse the info.json file that is in the artifact bundle.
+    struct ArtifactBundleInfo: Codable {
+        let artifacts: Artifact 
+
+        struct Artifact: Codable {
+            let lefthook: LefthookArtifact
+
+            struct LefthookArtifact: Codable {
+                let variants: [ArtifactVariant]
+
+                struct ArtifactVariant: Codable {
+                    let path: String
+                    let supportedTriples: [String]
+                }
+            }
+        }
+    }
+}

--- a/Executable/FileSystem.swift
+++ b/Executable/FileSystem.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+class FileSystem {
+    // The base absolute path when using "swift run"
+    static var pathWhereBinaryExecutedFrom: String {
+        return FileManager.default.currentDirectoryPath
+    }
+    
+    // The base absolute path when using "mint run"
+    static var pathWhereBinaryExists: String {
+        let fileURL = Bundle.main.executableURL!
+        let directoryURL = fileURL.deletingLastPathComponent()
+        return directoryURL.path
+    }
+    
+    // Given a relative path, return the expanded absolute path. Only return result if the path exists.
+    // Depending on if the executable is run by "swift run" or "mint run", the absolute path will be different.
+    // Get the absolute path to be able to find the artifact bundle and parse it.
+    static func getAbsolutePathThatExists(relativePath: String) -> String? {
+        let absolutePathSwiftRun = "\(pathWhereBinaryExecutedFrom)/\(relativePath)"
+        let absolutePathMintRun = "\(pathWhereBinaryExists)/\(relativePath)"
+        
+        if doesPathExist(path: absolutePathSwiftRun) {
+            return absolutePathSwiftRun
+        } else if doesPathExist(path: absolutePathMintRun) {
+            return absolutePathMintRun
+        }
+        
+        return nil
+    }
+    
+    static func doesPathExist(path: String) -> Bool {
+        return FileManager.default.fileExists(atPath: path)
+    }
+    
+    static func getSubdirectories(atAbsolutePath path: String) -> [String] {
+        let contents = (try? FileManager.default.contentsOfDirectory(at: URL(fileURLWithPath: path), includingPropertiesForKeys: nil)) ?? []
+        
+        var subdirectories: [String] = []
+        
+        for item in contents {
+            var isDirectory: ObjCBool = false
+            if FileManager.default.fileExists(atPath: item.path, isDirectory: &isDirectory) {
+                if isDirectory.boolValue {
+                    let absolutePathToSubdirectory = "\(path)/\(item.lastPathComponent)"
+                    subdirectories.append(absolutePathToSubdirectory)
+                }
+            }
+        }
+        
+        return subdirectories
+    }
+}

--- a/Executable/OS.swift
+++ b/Executable/OS.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Utility that helps determine what OS Swift is being executed on. 
+/// Helpful to determine the right binary to run for the given OS. 
+class OS {
+    /// Get the system triple that represents the OS that Swift is being executed on.
+    /// Based on the Swift Package Manager's implementation:
+    /// https://github.com/apple/swift-package-manager/blob/1c68e6cab56a3acba30d3ecea0c09209c6c7f565/Sources/Basics/Triple%2BBasics.swift#L84-L121
+    static func getSystemTriple() -> String? {
+        let process = Process()        
+        let stdoutPipe = Pipe()
+
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["swift", "-print-target-info"]
+        process.standardOutput = stdoutPipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            print("Error running process: \(error)")
+            return nil 
+        }
+        
+        let stdoutString = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let stdoutParsed: SwiftTargetInfo = try? JSONDecoder().decode(SwiftTargetInfo.self, from: stdoutString) else {
+            print("Unexpected error. Unable to parse JSON: \(stdoutString) into data type \(SwiftTargetInfo.self)")
+            return nil
+        }
+
+        return stdoutParsed.target.unversionedTriple
+    }
+
+    // Run "swift -print-target-info" on your computer. This struct is used to parse the output of that command.
+    struct SwiftTargetInfo: Codable {
+        let target: Target
+        
+        struct Target: Codable {
+            let unversionedTriple: String
+        }
+    }
+}

--- a/Executable/main.swift
+++ b/Executable/main.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+// Get arguments that were passed into this executable that we will forward to lefthook as args. 
+let lefthookArgs = Array(ProcessInfo.processInfo.arguments.dropFirst())
+
+guard let lefthookBinaryPath = ArtifactParser.getPathToLefthookBinary() else {
+    print("Error: Unable to find lefthook binary. Unable to run lefthook.")
+    exit(1)
+}
+
+// Run lefthook binary with the arguments that were passed into this executable.
+let process = Process()
+process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+process.arguments = [lefthookBinaryPath] + lefthookArgs
+
+do {
+    try process.run()
+    process.waitUntilExit()
+} catch {
+    print("Error running process: \(error)")
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,10 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "LefthookExecutable",
+            path: "Executable",
             plugins: [
                 .plugin(name: "ArtifactExpander")
-            ]
+            ]            
         ),
         .plugin(
             name: "ArtifactExpander",


### PR DESCRIPTION
Besides offering a swift plugin target, this commit adds an executable target to run lefthook. Having an executable target allows you to use tools like Mint to run lefthook.

The executable target supports both "swift run lefthook" and "mint run ..." for local development testing and mint testing.