### PR TITLE
Fix artifact path in checksum calculation and add macOS platform requirement

### DIFF
--- a/.github/workflows/publish-artifact-bundle.yml
+++ b/.github/workflows/publish-artifact-bundle.yml
@@ -76,7 +76,7 @@ jobs:
         git reset --hard
     - name: Update Package.swift
       run: |
-        sed -i '' "s/checksum: \".*\"/checksum: \"$(shasum -a 256 ${{ env.ARTIFACT_NAME }} | sed 's/ .*//')\"/g" ${{ inputs.binary_name }}/Package.swift
+        sed -i '' "s/checksum: \".*\"/checksum: \"$(shasum -a 256 ${{ env.ARTIFACT_PATH }}/${{ env.ARTIFACT_NAME }} | sed 's/ .*//')\"/g" ${{ inputs.binary_name }}/Package.swift
         sed -i '' -E "s/\/[0-9]+\.[0-9]+\.[0-9]+\//\/${{ env.PLUGIN_VERSION }}\//" ${{ inputs.binary_name }}/Package.swift
         sed -i '' -E "s/(https:\/\/github.com\/csjones\/lefthook-plugin.git\", exact: \")([0-9]+\.[0-9]+\.[0-9]+)/\1${{ env.PLUGIN_VERSION }}/" ${{ inputs.binary_name }}/README.md
     - name: Push Changes to GitHub

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "lefthook",
+    platforms: [.macOS(.v10_15)],
     products: [
         .executable(name: "lefthook", targets: ["LefthookExecutable"]),
         .plugin(name: "LefthookPlugin",targets: ["LefthookPlugin"])
@@ -34,7 +35,7 @@ let package = Package(
         .binaryTarget(
             name: "lefthook",
             url: "https://github.com/csjones/lefthook-plugin/releases/download/2.0.12/lefthook.artifactbundle.zip",
-            checksum: ""
+            checksum: "02cb640df588a63b35d5f1797d8c3d7e2060c461c7753277695fabd1548a8491"
         ),
     ],
     swiftLanguageVersions: [.v5]


### PR DESCRIPTION
- Fix sed command to use full artifact path when calculating checksum
- Add macOS 10.15 minimum platform requirement to Package.swift
- Update checksum for lefthook 2.0.12 artifact bundle